### PR TITLE
Pass kubernetes namespace to heketi

### DIFF
--- a/incubator/glusterfs/templates/heketi-deployment.yaml
+++ b/incubator/glusterfs/templates/heketi-deployment.yaml
@@ -35,6 +35,8 @@ spec:
           value: '14'
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET
           value: "y"
+        - name: HEKETI_KUBE_NAMESPACE
+          value: "{{.Release.Namespace}}"
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
This way one is able to deploy to any namespace e.g. `helm install . --namespace heketi`